### PR TITLE
Implement ability for admins to manually verify a user's email

### DIFF
--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -49,4 +49,17 @@ class UserController extends Controller
         }
         return redirect()->intended('/');
     }
+
+    /**
+     * Manually verify a user's email
+     */
+    public function manuallyVerify(Request $request, User $user): RedirectResponse
+    {
+        $request_user = $request->user();
+        if ($request_user->is_admin) {
+            $user->markEmailAsVerified();
+            return redirect()->intended(route('admin.users'));
+        }
+        return redirect()->intended('/');
+    }
 }

--- a/src/resources/js/Pages/Admin/Partials/UserManagementButtons.tsx
+++ b/src/resources/js/Pages/Admin/Partials/UserManagementButtons.tsx
@@ -3,6 +3,7 @@ import { router, useForm } from '@inertiajs/react';
 import { ActionIcon, Group, Tooltip } from '@mantine/core';
 import {
     IconUserCancel,
+    IconUserCheck,
     IconUserDown,
     IconUserShield,
     IconUserUp,
@@ -53,14 +54,27 @@ function UserManagementButton<T extends RouteName>({
 export default function UserManagementButtons({ user }: { user: User }) {
     return (
         <Group gap={'sm'}>
-            <UserManagementButton
-                label={user.is_admin ? 'Demote to User' : 'Promote to Admin'}
-                color={'ac-blue'}
-                routeName={'admin.users.setAdmin'}
-                params={{ user: user.id, admin: !user.is_admin }}
-            >
-                {user.is_admin ? <IconUserDown /> : <IconUserUp />}
-            </UserManagementButton>
+            {user.email_verified_at == null ? (
+                <UserManagementButton
+                    label={'Manually Verify'}
+                    color={'green'}
+                    routeName={'admin.users.manuallyVerify'}
+                    params={{ user: user.id }}
+                >
+                    <IconUserCheck />
+                </UserManagementButton>
+            ) : (
+                <UserManagementButton
+                    label={
+                        user.is_admin ? 'Demote to User' : 'Promote to Admin'
+                    }
+                    color={'ac-blue'}
+                    routeName={'admin.users.setAdmin'}
+                    params={{ user: user.id, admin: !user.is_admin }}
+                >
+                    {user.is_admin ? <IconUserDown /> : <IconUserUp />}
+                </UserManagementButton>
+            )}
             <UserManagementButton
                 label={user.is_banned ? 'Unban User' : 'Ban User'}
                 color={user.is_banned ? 'ac-purple' : 'ac-orange'}

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -22,6 +22,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/admin/users', [UserController::class, 'index'])->name('admin.users');
     Route::post('/admin/users/{user}/admin', [UserController::class, 'setAdmin'])->name('admin.users.setAdmin');
     Route::post('/admin/users/{user}/banned', [UserController::class, 'setBanned'])->name('admin.users.setBanned');
+    Route::post('/admin/users/{user}/verifyEmail', [UserController::class, 'manuallyVerify'])->name('admin.users.manuallyVerify');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
Adds a button to verify a user's email in the Actions column of the user administration page, shown in place of the promote/demote button if the user's email isn't yet verified.